### PR TITLE
modify the dns resolution order

### DIFF
--- a/helm/kubernetes-metrics-server-chart/Chart.yaml
+++ b/helm/kubernetes-metrics-server-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.3.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: kubernetes-metrics-server-chart
-version: 0.1.2-[[ .SHA ]]
+version: 0.1.3-[[ .SHA ]]

--- a/helm/kubernetes-metrics-server-chart/values.yaml
+++ b/helm/kubernetes-metrics-server-chart/values.yaml
@@ -36,6 +36,7 @@ args:
   - --logtostderr
 # enable this if you have self-signed certificates, see: https://github.com/kubernetes-incubator/metrics-server
   - --kubelet-insecure-tls
+  - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
 
 resources: {}
 


### PR DESCRIPTION
Modifying the DNS reolsution order for the metrics-server to use internaIP. It erduce the DNS cost for every requests and fixes problem on KVM

Closes https://github.com/giantswarm/giantswarm/issues/4981
Closes https://github.com/giantswarm/giantswarm/issues/5563