### PR TITLE
Switch to non-root user

### DIFF
--- a/helm/kubernetes-metrics-server-chart/Chart.yaml
+++ b/helm/kubernetes-metrics-server-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.3.2
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: kubernetes-metrics-server-chart
-version: 0.1.4-[[ .SHA ]]
+version: 0.2.0-[[ .SHA ]]

--- a/helm/kubernetes-metrics-server-chart/charts/migration/templates/job.yaml
+++ b/helm/kubernetes-metrics-server-chart/charts/migration/templates/job.yaml
@@ -22,6 +22,9 @@ spec:
           - key: resources.json
             path: resources.json
       serviceAccountName: {{ .Values.name }}
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
       containers:
       - name: {{ .Values.name }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/kubernetes-metrics-server-chart/charts/migration/templates/psp.yaml
+++ b/helm/kubernetes-metrics-server-chart/charts/migration/templates/psp.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes:
+  - 'secret'
+  - 'configMap'
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+

--- a/helm/kubernetes-metrics-server-chart/charts/migration/templates/rbac.yaml
+++ b/helm/kubernetes-metrics-server-chart/charts/migration/templates/rbac.yaml
@@ -41,6 +41,14 @@ rules:
   verbs:
   - "get"
   - "delete"
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Values.name }}
+  verbs:
+  - "use"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/helm/kubernetes-metrics-server-chart/charts/migration/values.yaml
+++ b/helm/kubernetes-metrics-server-chart/charts/migration/values.yaml
@@ -7,6 +7,9 @@ namespace: kube-system
 serviceType: managed
 k8sAppLabel: metrics-server
 
+userID: 1000
+groupID: 1000
+
 image:
   registry: quay.io
   repository: giantswarm/k8s-migrator

--- a/helm/kubernetes-metrics-server-chart/templates/cluster-role.yaml
+++ b/helm/kubernetes-metrics-server-chart/templates/cluster-role.yaml
@@ -24,4 +24,12 @@ rules:
     verbs:
     - get
     - create
+  - apiGroups:
+    - extensions
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+    resourceNames:
+    - {{ .Values.name }}
 {{- end -}}

--- a/helm/kubernetes-metrics-server-chart/templates/metric-server-service.yaml
+++ b/helm/kubernetes-metrics-server-chart/templates/metric-server-service.yaml
@@ -10,6 +10,6 @@ spec:
   ports:
     - port: 443
       protocol: TCP
-      targetPort: 443
+      targetPort: 10443
   selector:
     app: {{ .Values.k8sAppLabel }}

--- a/helm/kubernetes-metrics-server-chart/templates/metrics-server-deployment.yaml
+++ b/helm/kubernetes-metrics-server-chart/templates/metrics-server-deployment.yaml
@@ -24,6 +24,9 @@ spec:
         app: {{ .Values.k8sAppLabel }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
       priorityClassName: system-cluster-critical
       containers:
         - name: metrics-server

--- a/helm/kubernetes-metrics-server-chart/templates/psp.yaml
+++ b/helm/kubernetes-metrics-server-chart/templates/psp.yaml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes:
+  - 'secret'
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+

--- a/helm/kubernetes-metrics-server-chart/values.yaml
+++ b/helm/kubernetes-metrics-server-chart/values.yaml
@@ -7,6 +7,9 @@ namespace: kube-system
 serviceType: managed
 k8sAppLabel: metrics-server
 
+userID: 1000
+groupID: 1000
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
@@ -37,7 +40,8 @@ args:
 # enable this if you have self-signed certificates, see: https://github.com/kubernetes-incubator/metrics-server
   - --kubelet-insecure-tls
   - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP
-
+  - --cert-dir=/tmp
+  - --secure-port=10443
 resources: {}
 
 nodeSelector: {}

--- a/integration/templates/metrics_server_values.go
+++ b/integration/templates/metrics_server_values.go
@@ -23,6 +23,8 @@ image:
 args:
   - --logtostderr
   - --kubelet-insecure-tls
+  - --cert-dir=/tmp
+  - --secure-port=10443
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5983

---

- added `--cert=path` to be able to write self-generated certificates inside container
- switched https port from `443` to `10443` so that non-root user can run metrics-server without adding capabilities (we anyway use service for accessing pod workload)